### PR TITLE
Added justfile and .envrc for hot reloading

### DIFF
--- a/backend/.envrc
+++ b/backend/.envrc
@@ -1,0 +1,1 @@
+source venv/bin/activate

--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# Default command to list available commands
+default:
+    @just --list
+
+# Command to list all available commands
+list:
+    @echo "Available commands:"
+    @echo "  just run-api   - Run the Flask backend with hot reloading"
+    @echo "  just run-ui    - Run the React frontend with hot reloading"
+    @echo "  just run       - Run both backend and frontend simultaneously"
+
+# Run Flask backend (API) with direnv handling the virtual environment
+run-api:
+    cd backend
+    FLASK_ENV=development FLASK_APP=app flask run --reload
+
+# Run React frontend (UI) with hot reloading
+run-ui:
+    cd frontend && pnpm run dev
+
+# Run both backend and frontend simultaneously
+run:
+    just run-api &
+    just run-ui &
+    wait


### PR DESCRIPTION
### Description
- Added a `justfile` to automate running the backend (Flask) and frontend (React) with hot reloading.
- The `run-api` command runs the Flask backend in debug mode with `FLASK_ENV=development`.
- The `run-ui` command starts the React frontend with hot reloading using `pnpm run dev`.
- Both backend and frontend can be run simultaneously using `just run`.
- Included the `.envrc` for automatic virtual environment activation via `direnv` for the backend.

### How to Test
- Run `just run-api` to start the backend with Flask in hot reload mode.
- Run `just run-ui` to start the frontend with hot reloading.
- Run `just run` to start both backend and frontend simultaneously.

part of #6