### PR TITLE
Add Game Fetching Functionality and Implement Rate Limiting for Legion TD 2 API

### DIFF
--- a/backend/games_api.py
+++ b/backend/games_api.py
@@ -39,7 +39,8 @@ def fetch_games(start_time, end_time):
     params = {
         "dateAfter": start_time.isoformat(),
         "dateBefore": end_time.isoformat(),
-        "limit": config.max_limit  # Use the corrected limit of 50
+        "limit": config.max_limit,  # Use the corrected limit of 50
+        "offset": 0  # Start offset at 0 for the first call
     }
 
     all_games = []
@@ -60,6 +61,10 @@ def fetch_games(start_time, end_time):
         all_games.extend(data['games'])
 
         more_pages = data.get('has_more', False)
+        
+        # Increment the offset to get the next set of data
+        if more_pages:
+            params["offset"] += config.max_limit
 
         # Respect API rate limits with a delay
         time.sleep(1)

--- a/backend/games_api.py
+++ b/backend/games_api.py
@@ -7,9 +7,6 @@ from dotenv import load_dotenv
 from pyrate_limiter import Duration, Rate, Limiter, InMemoryBucket
 from typing import Optional
 
-# Load environment variables
-load_dotenv()
-
 @dataclass
 class APIConfig:
     api_url: str = "https://apiv2.legiontd2.com/games"
@@ -21,6 +18,10 @@ class APIConfig:
     burst_limiter: Limiter = field(init=False)
 
     def __post_init__(self):
+        # Load environment variables here as part of the initialization
+        load_dotenv()
+
+        self.api_key = os.getenv("API_KEY")
         if not self.api_key:
             raise ValueError("API_KEY environment variable is not set")
         self.limiter = Limiter(InMemoryBucket([self.rate]))

--- a/backend/games_api.py
+++ b/backend/games_api.py
@@ -35,9 +35,13 @@ def fetch_games(start_time, end_time):
         "x-api-key": config.api_key
     }
 
+    # Format the start and end times to match "YYYY-MM-DD HH:MM:SS"
+    start_time_str = start_time.strftime("%Y-%m-%d %H:%M:%S")
+    end_time_str = end_time.strftime("%Y-%m-%d %H:%M:%S")
+
     params = {
-        "dateAfter": start_time.isoformat(),
-        "dateBefore": end_time.isoformat(),
+        "dateAfter": start_time_str,
+        "dateBefore": end_time_str,
         "limit": config.max_limit,  # Use the corrected limit of 50
         "offset": 0  # Start offset at 0 for the first call
     }
@@ -62,7 +66,12 @@ def fetch_games(start_time, end_time):
             break
 
         data = response.json()
-        all_games.extend(data['games'])
+        
+        if isinstance(data, list):
+            all_games.extend(data)
+        else:
+            print("Unexpected response format")
+        return all_games
 
         more_pages = data.get('has_more', False)
         

--- a/backend/games_api.py
+++ b/backend/games_api.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 import os
 import requests
-import time
 from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 from pyrate_limiter import Duration, Rate, Limiter, InMemoryBucket

--- a/backend/games_api.py
+++ b/backend/games_api.py
@@ -1,0 +1,70 @@
+import os
+import requests
+import time
+from datetime import datetime, timedelta, timezone
+from dotenv import load_dotenv
+from pyrate_limiter import Duration, Rate, Limiter, InMemoryBucket
+
+# Load environment variables from the .env file
+load_dotenv()
+
+# API details
+API_URL = "https://apiv2.legiontd2.com/games"
+API_KEY = os.getenv("API_KEY")
+MAX_LIMIT = 50  # Adjusted based on the API's maximum limit of 50
+
+# Set up rate limiting
+rate = Rate(5, Duration.SECOND)
+burst_rate = Rate(100, Duration.MINUTE)
+limiter = Limiter(InMemoryBucket([rate]))
+burst_limiter = Limiter(InMemoryBucket([burst_rate]))
+
+# Function to call the API and fetch games
+def fetch_games(start_time, end_time):
+    headers = {
+        "x-api-key": API_KEY
+    }
+
+    params = {
+        "dateAfter": start_time.isoformat(),
+        "dateBefore": end_time.isoformat(),
+        "limit": MAX_LIMIT  # Use the corrected limit of 50
+    }
+
+    all_games = []
+    more_pages = True
+
+    while more_pages:
+        limiter.try_acquire("api_call")
+        burst_limiter.try_acquire("burst_api_call")
+
+        # Make the API call
+        response = requests.get(API_URL, headers=headers, params=params)
+
+        if response.status_code != 200:
+            print(f"Error: {response.status_code}, {response.text}")
+            break
+
+        data = response.json()
+
+        all_games.extend(data['games'])
+
+        more_pages = data.get('has_more', False)
+
+        # Respect API rate limits with a delay
+        time.sleep(1)
+
+    return all_games
+
+# Function to get games from the last hour
+def get_last_hour_games():
+    end_time = datetime.now(timezone.utc)
+    start_time = end_time - timedelta(hours=1)
+
+    games = fetch_games(start_time, end_time)
+    print(f"Retrieved {len(games)} games from the last hour.")
+    return games
+
+# Call on startup
+if __name__ == "__main__":
+    get_last_hour_games()


### PR DESCRIPTION
Introduces functionality to fetch games from the Legion TD 2 API within a specified time range. It includes the following features:
- **Game Fetching**: Added a function to fetch games within a start and end time window, with results paginated.
- **Rate Limiting**: Integrated `pyrate-limiter` to respect the Legion TD 2 API rate limits (5 requests per second, 100 requests burst limit).
- **Environment Variables**: Utilized Python `dotenv` to manage the API key and other environment variables.

### Notes:
- The function currently returns an error: `Entry not found` (404 error). I believe this is due to the lack of game data for the requested timeframe(?)
- I still don’t fully understand all the nuances of how the API handles queries and responses yet, but I’ve added comments and I'll be reviewing the code again tomorrow.

part of #18 